### PR TITLE
Adding buffer pools for stream decompression

### DIFF
--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -168,7 +168,9 @@ var dSize = func() int {
 }()
 
 // cPool is a pool of buffers for use in reader.compressionBuffer. Buffers are
-// taken from the pool in NewReaderDict, returned in reader.Close()
+// taken from the pool in NewReaderDict, returned in reader.Close(). Returns a
+// pointer to a slice to avoid the extra allocation of returning the slice as a
+// value.
 var cPool = sync.Pool{
 	New: func() interface{} {
 		buff := make([]byte, cSize)
@@ -177,7 +179,9 @@ var cPool = sync.Pool{
 }
 
 // dPool is a pool of buffers for use in reader.decompressionBuffer. Buffers are
-// taken from the pool in NewReaderDict, returned in reader.Close()
+// taken from the pool in NewReaderDict, returned in reader.Close(). Returns a
+// pointer to a slice to avoid the extra allocation of returning the slice as a
+// value.
 var dPool = sync.Pool{
 	New: func() interface{} {
 		buff := make([]byte, dSize)

--- a/zstd_stream.go
+++ b/zstd_stream.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"runtime"
+	"sync"
 	"unsafe"
 )
 
@@ -146,6 +147,44 @@ func (w *Writer) Close() error {
 	return nil
 }
 
+// cSize is the recommended size of reader.compressionBuffer. This func and
+// invocation allow for a one-time check for validity.
+var cSize = func() int {
+	v := int(C.ZBUFF_recommendedDInSize())
+	if v <= 0 {
+		panic(fmt.Errorf("ZBUFF_recommendedDInSize() returned invalid size: %v", v))
+	}
+	return v
+}()
+
+// dSize is the recommended size of reader.decompressionBuffer. This func and
+// invocation allow for a one-time check for validity.
+var dSize = func() int {
+	v := int(C.ZBUFF_recommendedDOutSize())
+	if v <= 0 {
+		panic(fmt.Errorf("ZBUFF_recommendedDOutSize() returned invalid size: %v", v))
+	}
+	return v
+}()
+
+// cPool is a pool of buffers for use in reader.compressionBuffer. Buffers are
+// taken from the pool in NewReaderDict, returned in reader.Close()
+var cPool = sync.Pool{
+	New: func() interface{} {
+		buff := make([]byte, cSize)
+		return &buff
+	},
+}
+
+// dPool is a pool of buffers for use in reader.decompressionBuffer. Buffers are
+// taken from the pool in NewReaderDict, returned in reader.Close()
+var dPool = sync.Pool{
+	New: func() interface{} {
+		buff := make([]byte, dSize)
+		return &buff
+	},
+}
+
 // reader is an io.ReadCloser that decompresses when read from.
 type reader struct {
 	ctx                 *C.ZBUFF_DCtx
@@ -181,22 +220,13 @@ func NewReaderDict(r io.Reader, dict []byte) io.ReadCloser {
 			unsafe.Pointer(&dict[0]),
 			C.size_t(len(dict)))))
 	}
-	cSize := int(C.ZBUFF_recommendedDInSize())
-	dSize := int(C.ZBUFF_recommendedDOutSize())
-	if cSize <= 0 {
-		panic(fmt.Errorf("ZBUFF_recommendedDInSize() returned invalid size: %v", cSize))
-	}
-	if dSize <= 0 {
-		panic(fmt.Errorf("ZBUFF_recommendedDOutSize() returned invalid size: %v", dSize))
-	}
-
-	compressionBuffer := make([]byte, cSize)
-	decompressionBuffer := make([]byte, dSize)
+	compressionBufferP := cPool.Get().(*[]byte)
+	decompressionBufferP := dPool.Get().(*[]byte)
 	return &reader{
 		ctx:                 ctx,
 		dict:                dict,
-		compressionBuffer:   compressionBuffer,
-		decompressionBuffer: decompressionBuffer,
+		compressionBuffer:   *compressionBufferP,
+		decompressionBuffer: *decompressionBufferP,
 		firstError:          err,
 		recommendedSrcSize:  cSize,
 		underlyingReader:    r,
@@ -205,6 +235,10 @@ func NewReaderDict(r io.Reader, dict []byte) io.ReadCloser {
 
 // Close frees the allocated C objects
 func (r *reader) Close() error {
+	cb := r.compressionBuffer
+	db := r.decompressionBuffer
+	cPool.Put(&cb)
+	dPool.Put(&db)
 	return getError(int(C.ZBUFF_freeDCtx(r.ctx)))
 }
 

--- a/zstd_stream_test.go
+++ b/zstd_stream_test.go
@@ -191,6 +191,7 @@ func BenchmarkStreamDecompression(b *testing.B) {
 		if err != nil {
 			b.Fatalf("Failed to decompress: %s", err)
 		}
+		r.Close()
 	}
 }
 


### PR DESCRIPTION
Digging into pprof, there was a lot of time spent in allocations and in GC. The allocations seemed to be mostly focused on `NewReaderDict`. In that method, two []byte slices were allocated. The size of those slices is based on compile-time decisions in the zstd C library. In an attempt to improve that situation, two changes were made:

* The sizes of those buffers are read, casted, and checked once
* The buffers come from a pair of `sync.Pool`s in the `NewReaderDict` factory method, returned to the pool in `reader.Close`.

Using the following test:
```
$ PAYLOAD=zstd_decompress.c go test \
    -bench BenchmarkStreamDecompression \
    -benchtime=5s \
    -benchmem
```

The number of bytes allocated per decompression dropped to 1/705 of previous:
```
pkg: github.com/TriggerMail/zstd
BenchmarkStreamDecompression      100000        121617 ns/op     595.48 MB/s         384 B/op         10 allocs/op

pkg: github.com/DataDog/zstd
BenchmarkStreamDecompression       50000        156142 ns/op     463.81 MB/s      270640 B/op         10 allocs/op
```

Note that this improvement is only in the Go-managed heap memory, not additional heap allocations in creating the zstd context. Because those are freed explicitly in `reader.Close`, the concern is heap fragmentation.